### PR TITLE
ci(release): run Release Please on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: release
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+  push:
+    branches: [main]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    uses: parkerbxyz/.github/.github/workflows/release.yml@main
+  release-please:
+    uses: parkerbxyz/.github/.github/workflows/release-please.yml@main
     secrets: inherit
+    with:
+      release-type: 'node'


### PR DESCRIPTION
This repo has Release Please configuration, but its release workflow only ran after a GitHub Release already existed. That meant pushes to `main` could not open or update release PRs like the other action repos do.

This updates the workflow to match `suggest-changes`, `render-liquid-file`, and `json-to-markdown-table`: run on pushes to `main`, call the shared `release-please.yml` workflow, grant pull request write access, and pass the Node release type.