### PR TITLE
ci(test): add permissions to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/parkerbxyz/add-anchor-links/security/code-scanning/1](https://github.com/parkerbxyz/add-anchor-links/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so the workflow does not rely on repository/org defaults.  
Best minimal, non-breaking fix here is to set:

- `contents: read`

at workflow root (applies to all jobs, including the reusable workflow call, unless overridden). This satisfies CodeQL’s requirement and documents intent without changing behavior beyond restricting token scope to read-only contents, which is typically sufficient for test workflows.

Edit region: directly after the `on:` trigger block and before `concurrency:` (or any top-level position is valid YAML, but this location is clear and conventional).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
